### PR TITLE
Feature/add phone number to proxy

### DIFF
--- a/pkg/incoming_phone_numbers.go
+++ b/pkg/incoming_phone_numbers.go
@@ -129,8 +129,8 @@ func (twilio *Twilio) CreateNewIncomingPhoneNumber(options CreateNewIncomingPhon
 }
 
 // DeleteIncomingPhoneNumber will release an existing IncomingPhoneNumber from Twilio.
-func (twilio *Twilio) DeleteIncomingPhoneNumber(sid string) error {
-	req, err := http.NewRequest(http.MethodDelete, twilio.url("IncomingPhoneNumbers/"+sid+".json"), nil)
+func (twilio *Twilio) DeleteIncomingPhoneNumber(phoneNumberSID string) error {
+	req, err := http.NewRequest(http.MethodDelete, twilio.url("IncomingPhoneNumbers/"+phoneNumberSID+".json"), nil)
 
 	if err != nil {
 		return err

--- a/pkg/proxy_phone_numbers.go
+++ b/pkg/proxy_phone_numbers.go
@@ -9,14 +9,14 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-// AddPhoneNumberToProxyServiceOptions ...
+// AddPhoneNumberToProxyServiceOptions are all of the options that can be provided to a AddPhoneNumberToProxyService call.
 type AddPhoneNumberToProxyServiceOptions struct {
 	SID         string `url:"Sid,omitempty"`
 	PhoneNumber string `url:",omitempty"`
 	IsReserved  *bool  `url:",omitempty"`
 }
 
-// ProxyPhoneNumber ...
+// ProxyPhoneNumber represents an IncomingPhoneNumber that has been attached to a ProxyService within Twilio.
 type ProxyPhoneNumber struct {
 	SID          string                       `json:"sid"`
 	AccountSID   string                       `json:"account_sid"`
@@ -32,7 +32,7 @@ type ProxyPhoneNumber struct {
 	InUse        int                          `json:"in_use"`
 }
 
-// ProxyPhoneNumberCapabilities ...
+// ProxyPhoneNumberCapabilities describes the capabilities afforded to a given ProxyPhoneNumber according to Twilio.
 type ProxyPhoneNumberCapabilities struct {
 	MMSInbound    bool `json:"mms_inbound"`
 	MMSOutbound   bool `json:"mms_outbound"`
@@ -42,7 +42,7 @@ type ProxyPhoneNumberCapabilities struct {
 	VoiceOutbound bool `json:"voice_outbound"`
 }
 
-// AddPhoneNumberToProxyService ...
+// AddPhoneNumberToProxyService attaches a phone number to the given proxy service in Twilio.
 func (twilio *Twilio) AddPhoneNumberToProxyService(service string, options AddPhoneNumberToProxyServiceOptions) (*ProxyPhoneNumber, error) {
 	params, err := query.Values(options)
 

--- a/pkg/proxy_phone_numbers.go
+++ b/pkg/proxy_phone_numbers.go
@@ -84,3 +84,36 @@ func (twilio *Twilio) AddPhoneNumberToProxyService(service string, options AddPh
 
 	return response, nil
 }
+
+// RemovePhoneNumberFromProxyService remove the given IncomingPhoneNumber from the given ProxyService within Twilio.
+func (twilio *Twilio) RemovePhoneNumberFromProxyService(serviceSID, phoneNumberSID string) error {
+	resource := "Services/" + serviceSID + "/PhoneNumbers/" + phoneNumberSID
+
+	req, err := http.NewRequest(http.MethodDelete, twilio.proxyURL(resource), nil)
+
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth(twilio.credentials())
+
+	res, err := twilio.delete(req)
+
+	if err != nil {
+		return nil
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		decoder := json.NewDecoder(res.Body)
+
+		err = new(Exception)
+
+		decoder.Decode(err)
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/proxy_phone_numbers.go
+++ b/pkg/proxy_phone_numbers.go
@@ -1,0 +1,86 @@
+package twiligo
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/go-querystring/query"
+)
+
+// AddPhoneNumberToProxyServiceOptions ...
+type AddPhoneNumberToProxyServiceOptions struct {
+	SID         string `url:"Sid,omitempty"`
+	PhoneNumber string `url:",omitempty"`
+	IsReserved  *bool  `url:",omitempty"`
+}
+
+// ProxyPhoneNumber ...
+type ProxyPhoneNumber struct {
+	SID          string                       `json:"sid"`
+	AccountSID   string                       `json:"account_sid"`
+	ServiceSID   string                       `json:"service_sid"`
+	DateCreated  time.Time                    `json:"date_created"`
+	DateUpdated  time.Time                    `json:"date_updated"`
+	PhoneNumber  string                       `json:"phone_number"`
+	FriendlyName string                       `json:"friendly_name"`
+	IsoCountry   string                       `json:"iso_country"`
+	Capabilities ProxyPhoneNumberCapabilities `json:"capabilities"`
+	URL          string                       `json:"url"`
+	IsReserved   bool                         `json:"is_reserved"`
+	InUse        int                          `json:"in_use"`
+}
+
+// ProxyPhoneNumberCapabilities ...
+type ProxyPhoneNumberCapabilities struct {
+	MMSInbound    bool `json:"mms_inbound"`
+	MMSOutbound   bool `json:"mms_outbound"`
+	SMSInbound    bool `json:"sms_inbound"`
+	SMSOutbound   bool `json:"sms_outbound"`
+	VoiceInbound  bool `json:"voice_inbound"`
+	VoiceOutbound bool `json:"voice_outbound"`
+}
+
+// AddPhoneNumberToProxyService ...
+func (twilio *Twilio) AddPhoneNumberToProxyService(service string, options AddPhoneNumberToProxyServiceOptions) (*ProxyPhoneNumber, error) {
+	params, err := query.Values(options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	resource := "Services/" + service + "/PhoneNumbers"
+
+	req, err := http.NewRequest(http.MethodPost, twilio.proxyURL(resource), strings.NewReader(params.Encode()))
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(twilio.credentials())
+
+	res, err := twilio.post(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	decoder := json.NewDecoder(res.Body)
+
+	if res.StatusCode != http.StatusCreated {
+		err = new(Exception)
+
+		decoder.Decode(err)
+
+		return nil, err
+	}
+
+	response := new(ProxyPhoneNumber)
+
+	decoder.Decode(&response)
+
+	return response, nil
+}

--- a/pkg/proxy_phone_numbers_test.go
+++ b/pkg/proxy_phone_numbers_test.go
@@ -1,0 +1,137 @@
+package twiligo_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	twiligo "github.com/craigpaul/twiligo/pkg"
+)
+
+const addedPhoneNumberToServiceResponse = `{
+	"sid": "PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"service_sid": "KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"date_created": "2020-07-30T00:00:00Z",
+	"date_updated": "2020-07-30T00:00:00Z",
+	"phone_number": "+15555555555",
+	"friendly_name": "(555) 555-5555",
+	"iso_country": "CA",
+	"capabilities": {
+		"mms_inbound": true,
+		"mms_outbound": true,
+		"sms_inbound": true,
+		"sms_outbound": true,
+		"voice_inbound": true,
+		"voice_outbound": true,
+	},
+	"url": "https://proxy.twilio.com/v1/Services/KSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/PhoneNumbers/PNXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"is_reserved": false,
+	"in_use": 0
+}`
+
+const alreadyAddedToServiceResponse = `{
+	"code": 80104,
+	"message": "PhoneNumber has already been added to Service",
+	"more_info": "https://www.twilio.com/docs/errors/80104",
+	"status": 400
+}`
+
+func TestWillMakeRequestToAddPhoneNumberToExistingProxyServiceSuccessfully(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		expected := "Services/KS123/PhoneNumbers"
+
+		if strings.Contains(req.URL.Path, expected) == false {
+			t.Logf("Incorrect URL supplied, expecting URL to contain [%s], but received [%s]", expected, req.URL.Path)
+			t.Fail()
+		}
+
+		if req.Header.Get("Authorization") == "" {
+			t.Log("Missing authorization credentials, they should be supplied via the Authorization header")
+			t.Fail()
+		}
+
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(addedPhoneNumberToServiceResponse)),
+			StatusCode: http.StatusCreated,
+			Header:     make(http.Header),
+		}
+	})
+
+	response, err := twilio.AddPhoneNumberToProxyService("KS123", twiligo.AddPhoneNumberToProxyServiceOptions{})
+
+	if err != nil {
+		t.Logf("Error was incorrectly returned, was not expecting the following error: %s", err)
+		t.Fail()
+	}
+
+	if response == nil {
+		t.Log("Did not receive the expected response")
+		t.Fail()
+	}
+}
+
+func TestWillIncludeProperRequestBodyParametersWhenMakingRequestToAddPhoneNumberToExistingProxyServiceSuccessfully(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		body, _ := ioutil.ReadAll(req.Body)
+		params, _ := url.ParseQuery(string(body))
+
+		if params.Get("Sid") != "PN123" {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", "PN123", params.Get("Sid"))
+			t.Fail()
+		}
+
+		if params.Get("PhoneNumber") != "+15555555555" {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", "+15555555555", params.Get("PhoneNumber"))
+			t.Fail()
+		}
+
+		if params.Get("IsReserved") != "false" {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", "false", params.Get("IsReserved"))
+			t.Fail()
+		}
+
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(addedPhoneNumberToServiceResponse)),
+			StatusCode: http.StatusCreated,
+			Header:     make(http.Header),
+		}
+	})
+
+	reserved := false
+
+	twilio.AddPhoneNumberToProxyService("KS123", twiligo.AddPhoneNumberToProxyServiceOptions{
+		SID:         "PN123",
+		PhoneNumber: "+15555555555",
+		IsReserved:  &reserved,
+	})
+}
+
+func TestWillHandleErrorResponsesWhenMakingRequestToAddPhoneNumberToExistingProxyServiceSuccessfully(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(alreadyAddedToServiceResponse)),
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+		}
+	})
+
+	response, err := twilio.AddPhoneNumberToProxyService("KS123", twiligo.AddPhoneNumberToProxyServiceOptions{
+		SID: "PN123",
+	})
+
+	if response != nil {
+		t.Logf("Response was incorrectly returned, was not expecting the following response: %v", response)
+		t.Fail()
+	}
+
+	expected := "PhoneNumber has already been added to Service"
+
+	if err.Error() != expected {
+		t.Logf("Incorrect error returned, expected [%s], but received [%s]", expected, err)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This PR looks to add the ability to attach an already purchased incoming phone number to an existing proxy service within Twilio. The ability to remove that phone number from the proxy service will come in a future PR.