### PR TITLE
Feature/delete phone number from proxy

### DIFF
--- a/pkg/incoming_phone_numbers.go
+++ b/pkg/incoming_phone_numbers.go
@@ -129,8 +129,8 @@ func (twilio *Twilio) CreateNewIncomingPhoneNumber(options CreateNewIncomingPhon
 }
 
 // DeleteIncomingPhoneNumber will release an existing IncomingPhoneNumber from Twilio.
-func (twilio *Twilio) DeleteIncomingPhoneNumber(sid string) error {
-	req, err := http.NewRequest(http.MethodDelete, twilio.url("IncomingPhoneNumbers/"+sid+".json"), nil)
+func (twilio *Twilio) DeleteIncomingPhoneNumber(phoneNumberSID string) error {
+	req, err := http.NewRequest(http.MethodDelete, twilio.url("IncomingPhoneNumbers/"+phoneNumberSID+".json"), nil)
 
 	if err != nil {
 		return err

--- a/pkg/proxy_phone_numbers.go
+++ b/pkg/proxy_phone_numbers.go
@@ -85,7 +85,7 @@ func (twilio *Twilio) AddPhoneNumberToProxyService(service string, options AddPh
 	return response, nil
 }
 
-// RemovePhoneNumberFromProxyService ...
+// RemovePhoneNumberFromProxyService remove the given IncomingPhoneNumber from the given ProxyService within Twilio.
 func (twilio *Twilio) RemovePhoneNumberFromProxyService(service, number string) error {
 	resource := "Services/" + service + "/PhoneNumbers/" + number
 

--- a/pkg/proxy_phone_numbers.go
+++ b/pkg/proxy_phone_numbers.go
@@ -84,3 +84,36 @@ func (twilio *Twilio) AddPhoneNumberToProxyService(service string, options AddPh
 
 	return response, nil
 }
+
+// RemovePhoneNumberFromProxyService ...
+func (twilio *Twilio) RemovePhoneNumberFromProxyService(service, number string) error {
+	resource := "Services/" + service + "/PhoneNumbers/" + number
+
+	req, err := http.NewRequest(http.MethodDelete, twilio.proxyURL(resource), nil)
+
+	if err != nil {
+		return err
+	}
+
+	req.SetBasicAuth(twilio.credentials())
+
+	res, err := twilio.delete(req)
+
+	if err != nil {
+		return nil
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		decoder := json.NewDecoder(res.Body)
+
+		err = new(Exception)
+
+		decoder.Decode(err)
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/proxy_phone_numbers.go
+++ b/pkg/proxy_phone_numbers.go
@@ -86,8 +86,8 @@ func (twilio *Twilio) AddPhoneNumberToProxyService(service string, options AddPh
 }
 
 // RemovePhoneNumberFromProxyService remove the given IncomingPhoneNumber from the given ProxyService within Twilio.
-func (twilio *Twilio) RemovePhoneNumberFromProxyService(service, number string) error {
-	resource := "Services/" + service + "/PhoneNumbers/" + number
+func (twilio *Twilio) RemovePhoneNumberFromProxyService(serviceSID, phoneNumberSID string) error {
+	resource := "Services/" + serviceSID + "/PhoneNumbers/" + phoneNumberSID
 
 	req, err := http.NewRequest(http.MethodDelete, twilio.proxyURL(resource), nil)
 


### PR DESCRIPTION
This PR builds off of the previous PR in an effort to add the ability to remove phone numbers previously attached to an existing proxy service within Twilio.