### PR TITLE
Feature/get phone number type

### DIFF
--- a/pkg/available_phone_numbers.go
+++ b/pkg/available_phone_numbers.go
@@ -111,7 +111,7 @@ func (twilio *Twilio) GetAvailablePhoneNumbers(country string, number PhoneNumbe
 	return response.AvailablePhoneNumbers, nil
 }
 
-// GetPhoneNumberType ...
+// GetPhoneNumberType will convert a given integer into a PhoneNumberType by the given country. Certain countries do not support all PhoneNumberType values, so this function can be used as a safe mapping based on the values from this document https://support.twilio.com/hc/en-us/articles/223183068-Twilio-international-phone-number-availability-and-their-capabilities. Note: Not all cases are currently supported, but can be amended as necessary.
 func (twilio *Twilio) GetPhoneNumberType(number int, country string) PhoneNumberType {
 	numberType := PhoneNumberType(number)
 

--- a/pkg/available_phone_numbers.go
+++ b/pkg/available_phone_numbers.go
@@ -111,6 +111,17 @@ func (twilio *Twilio) GetAvailablePhoneNumbers(country string, number PhoneNumbe
 	return response.AvailablePhoneNumbers, nil
 }
 
+// GetPhoneNumberType ...
+func (twilio *Twilio) GetPhoneNumberType(number int, country string) PhoneNumberType {
+	numberType := PhoneNumberType(number)
+
+	if (country == "CA" || country == "US") && numberType == Mobile {
+		numberType = Local
+	}
+
+	return numberType
+}
+
 func (number PhoneNumberType) String() string {
 	return map[PhoneNumberType]string{
 		Local:    "Local",

--- a/pkg/available_phone_numbers_test.go
+++ b/pkg/available_phone_numbers_test.go
@@ -206,3 +206,23 @@ func TestWillHandleErrorResponsesWhenMakingRequestToGetAvailablePhoneNumbers(t *
 		t.Fail()
 	}
 }
+
+func TestWillConvertGivenNumberTypeAndCountryToMatchingPhoneNumberTypeToPrevent404ErrorsThroughTwilioAPI(t *testing.T) {
+	cases := map[string]map[twiligo.PhoneNumberType]twiligo.PhoneNumberType{
+		"CA": {twiligo.Mobile: twiligo.Local},
+		"US": {twiligo.Mobile: twiligo.Local},
+		"FR": {twiligo.Mobile: twiligo.Mobile, twiligo.Local: twiligo.Local},
+	}
+
+	twilio := twiligo.New("123", "456")
+
+	for country, values := range cases {
+		for given, expected := range values {
+			numberType := twilio.GetPhoneNumberType(int(given), country)
+
+			if numberType != expected {
+				t.Logf("Incorrect number type returned, expected [%s], but received [%s]", expected, numberType)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR aims to add a convenience method to convert `int` constants into `PhoneNumberType` structs based on a given country. [Certain countries do not have certain phone number types.](https://support.twilio.com/hc/en-us/articles/223183068-Twilio-international-phone-number-availability-and-their-capabilities) Right now, this is only covering a small subset of cases, however, this can be amended when more cases become necessary.