### PR TITLE
Feature/create chat service

### DIFF
--- a/pkg/available_phone_numbers.go
+++ b/pkg/available_phone_numbers.go
@@ -112,7 +112,7 @@ func (twilio *Twilio) GetAvailablePhoneNumbers(country string, number PhoneNumbe
 }
 
 // GetPhoneNumberType will convert a given integer into a PhoneNumberType by the given country. Certain countries do not support all PhoneNumberType values, so this function can be used as a safe mapping based on the values from this document https://support.twilio.com/hc/en-us/articles/223183068-Twilio-international-phone-number-availability-and-their-capabilities. Note: Not all cases are currently supported, but can be amended as necessary.
-func (twilio *Twilio) GetPhoneNumberType(number int, country string) PhoneNumberType {
+func GetPhoneNumberType(number int, country string) PhoneNumberType {
 	numberType := PhoneNumberType(number)
 
 	if (country == "CA" || country == "US") && numberType == Mobile {

--- a/pkg/available_phone_numbers_test.go
+++ b/pkg/available_phone_numbers_test.go
@@ -214,11 +214,9 @@ func TestWillConvertGivenNumberTypeAndCountryToMatchingPhoneNumberTypeToPrevent4
 		"FR": {twiligo.Mobile: twiligo.Mobile, twiligo.Local: twiligo.Local},
 	}
 
-	twilio := twiligo.New("123", "456")
-
 	for country, values := range cases {
 		for given, expected := range values {
-			numberType := twilio.GetPhoneNumberType(int(given), country)
+			numberType := twiligo.GetPhoneNumberType(int(given), country)
 
 			if numberType != expected {
 				t.Logf("Incorrect number type returned, expected [%s], but received [%s]", expected, numberType)

--- a/pkg/chat_services.go
+++ b/pkg/chat_services.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-// ChatService ...
+// ChatService represents a Twilio Chat service that owns one or more channels, users, messages, etc.
 type ChatService struct {
 	AccountSID                   string    `json:"account_sid"`
 	DateCreated                  time.Time `json:"date_created"`
@@ -64,7 +64,7 @@ type createNewChatServiceOptions struct {
 	FriendlyName string
 }
 
-// CreateNewChatService ...
+// CreateNewChatService creates a new chat service in Twilio.
 func (twilio *Twilio) CreateNewChatService(name string) (*ChatService, error) {
 	params, err := query.Values(createNewChatServiceOptions{FriendlyName: name})
 

--- a/pkg/chat_services.go
+++ b/pkg/chat_services.go
@@ -1,0 +1,106 @@
+package twiligo
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/go-querystring/query"
+)
+
+// ChatService ...
+type ChatService struct {
+	AccountSID                   string    `json:"account_sid"`
+	DateCreated                  time.Time `json:"date_created"`
+	DateUpdated                  time.Time `json:"date_updated"`
+	DefaultChannelCreatorRoleSID string    `json:"default_channel_creator_role_sid"`
+	DefaultChannelRoleSID        string    `json:"default_channel_role_sid"`
+	DefaultServiceRoleSID        string    `json:"default_service_role_sid"`
+	FriendlyName                 string    `json:"friendly_name"`
+	Limits                       struct {
+		ChannelMembers int `json:"channel_members"`
+		UserChannels   int `json:"user_channels"`
+	} `json:"limits"`
+	Links struct {
+		Channels string `json:"channels"`
+		Users    string `json:"users"`
+		Roles    string `json:"roles"`
+		Bindings string `json:"bindings"`
+	} `json:"links"`
+	Notifications struct {
+		RemovedFromChannel struct {
+			Enabled bool `json:"enabled"`
+		} `json:"removed_from_channel"`
+		LogEnabled     bool `json:"log_enabled"`
+		AddedToChannel struct {
+			Enabled bool `json:"enabled"`
+		} `json:"added_to_channel"`
+		NewMessage struct {
+			Enabled bool `json:"enabled"`
+		} `json:"new_message"`
+		InvitedToChannel struct {
+			Enabled bool `json:"enabled"`
+		} `json:"invited_to_channel"`
+	} `json:"notifications"`
+	Media struct {
+		SizeLimitMB        int    `json:"size_limit_mb"`
+		CompabilityMessage string `json:"compatibility_message"`
+	} `json:"media"`
+	PostWebhookURL         *string   `json:"post_webhook_url"`
+	PreWebhookURL          *string   `json:"pre_webhook_url"`
+	PreWebhookRetryCount   int       `json:"pre_webhook_retry_count"`
+	PostWebhookRetryCount  int       `json:"post_webhook_retry_count"`
+	ReachabilityEnabled    bool      `json:"reachability_enabled"`
+	ReadStatusEnabled      bool      `json:"read_status_enabled"`
+	SID                    string    `json:"sid"`
+	TypingIndicatorTimeout int       `json:"typing_indicator_timout"`
+	URL                    string    `json:"url"`
+	WebhookFilters         *[]string `json:"webhook_filters"`
+	WebhookMethod          *string   `json:"webhook_method"`
+}
+
+type createNewChatServiceOptions struct {
+	FriendlyName string
+}
+
+// CreateNewChatService ...
+func (twilio *Twilio) CreateNewChatService(name string) (*ChatService, error) {
+	params, err := query.Values(createNewChatServiceOptions{FriendlyName: name})
+
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, twilio.chatURL("Services"), strings.NewReader(params.Encode()))
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(twilio.credentials())
+
+	res, err := twilio.post(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	decoder := json.NewDecoder(res.Body)
+
+	if res.StatusCode != http.StatusCreated {
+		err = new(Exception)
+
+		decoder.Decode(err)
+
+		return nil, err
+	}
+
+	response := new(ChatService)
+
+	decoder.Decode(&response)
+
+	return response, nil
+}

--- a/pkg/chat_services_test.go
+++ b/pkg/chat_services_test.go
@@ -1,0 +1,133 @@
+package twiligo_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const createdChatServiceResponse = `{
+	"account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"date_created": "2020-07-30T00:00:00Z",
+	"date_updated": "2020-07-30T00:00:00Z",
+	"default_channel_creator_role_sid": "RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"default_channel_role_sid": "RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"default_service_role_sid": "RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"friendly_name": "Friendly Name",
+	"limits": {
+		"user_channels": 250,
+		"channel_members": 100
+	},
+	"links": {
+		"channels": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Channels",
+		"bindings": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Bindings",
+		"users": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Users",
+		"roles": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Roles"
+	},
+	"notifications": {
+		"removed_from_channel": {
+			"enabled": false
+		},
+		"log_enabled": false,
+		"added_to_channel": {
+			"enabled": false
+		},
+		"new_message": {
+			"enabled": false
+		},
+		"invited_to_channel": {
+			"enabled": false
+		}
+	},
+	"media": {
+		"compatibility_message": "Media messages are not supported by your client",
+		"size_limit_mb": 150
+	},
+	"post_webhook_url": null,
+	"pre_webhook_url": null,
+	"pre_webhook_retry_count": 0,
+	"post_webhook_retry_count": 0,
+	"reachability_enabled": false,
+	"read_status_enabled": true,
+	"sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"typing_indicator_timeout": 5,
+	"url": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"webhook_filters": null,
+	"webhook_method": null
+}`
+
+const missingChatServiceNameResponse = `{
+	"code": 20001,
+	"message": "Missing required parameter FriendlyName in the post body",
+	"more_info": "https://www.twilio.com/docs/errors/20001",
+	"status": 400
+}`
+
+func TestWillMakeRequestToCreateNewChatServiceSuccessfully(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		expected := "Services"
+
+		if strings.Contains(req.URL.Path, expected) == false {
+			t.Logf("Incorrect URL supplied, expecting URL to contain [%s], but received [%s]", expected, req.URL.Path)
+			t.Fail()
+		}
+
+		if req.Header.Get("Authorization") == "" {
+			t.Log("Missing authorization credentials, they should be supplied via the Authorization header")
+			t.Fail()
+		}
+
+		body, _ := ioutil.ReadAll(req.Body)
+		params, _ := url.ParseQuery(string(body))
+
+		if params.Get("FriendlyName") != "Friendly Name" {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", "Friendly Name", params.Get("FriendlyName"))
+			t.Fail()
+		}
+
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(createdChatServiceResponse)),
+			StatusCode: http.StatusCreated,
+			Header:     make(http.Header),
+		}
+	})
+
+	response, err := twilio.CreateNewChatService("Friendly Name")
+
+	if err != nil {
+		t.Logf("Error was incorrectly returned, was not expecting the following error: %s", err)
+		t.Fail()
+	}
+
+	if response == nil {
+		t.Log("Did not receive the expected response")
+		t.Fail()
+	}
+}
+
+func TestWillHandleErrorResponsesWhenMakingRequestToCreateNewChatService(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(missingChatServiceNameResponse)),
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+		}
+	})
+
+	response, err := twilio.CreateNewChatService("")
+
+	if response != nil {
+		t.Logf("Response was incorrectly returned, was not expecting the following response: %v", response)
+		t.Fail()
+	}
+
+	expected := "Missing required parameter FriendlyName in the post body"
+
+	if err.Error() != expected {
+		t.Logf("Incorrect error returned, expected [%s], but received [%s]", expected, err)
+		t.Fail()
+	}
+}

--- a/pkg/chat_users.go
+++ b/pkg/chat_users.go
@@ -1,0 +1,83 @@
+package twiligo
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/go-querystring/query"
+)
+
+// ChatUser represents a Twilio Chat user identified by their unique Identity property within Twilio.
+type ChatUser struct {
+	SID                 string    `json:"sid"`
+	AccountSID          string    `json:"account_sid"`
+	ServiceSID          string    `json:"service_sid"`
+	RoleSID             string    `json:"role_sid"`
+	Identity            string    `json:"identity"`
+	Attributes          string    `json:"attributes"`
+	IsOnline            *bool     `json:"is_online"`
+	IsNotifiable        *bool     `json:"is_notifiable"`
+	FriendlyName        *string   `json:"friendly_name"`
+	JoinedChannelsCount int       `json:"joined_channels_count"`
+	DateCreated         time.Time `json:"date_created"`
+	DateUpdated         time.Time `json:"date_updated"`
+	Links               struct {
+		UserChannels string `json:"user_channels"`
+		USerBindings string `json:"user_bindings"`
+	} `json:"links"`
+	URL string `json:"url"`
+}
+
+// CreateNewChatUserOptions are all of the options that can be provided to a CreateNewChatUser call.
+type CreateNewChatUserOptions struct {
+	RoleSID      string `url:"RoleSid,omitempty"`
+	Attributes   string `url:",omitempty"`
+	FriendlyName string `url:",omitempty"`
+}
+
+// CreateNewChatUser creates a new chat user for the given chat service in Twilio.
+func (twilio *Twilio) CreateNewChatUser(identity, serviceSID string, options CreateNewChatUserOptions) (*ChatUser, error) {
+	params, err := query.Values(options)
+
+	if err != nil {
+		return nil, err
+	}
+
+	params.Add("Identity", identity)
+
+	resource := "Services/" + serviceSID + "/Users"
+
+	req, err := http.NewRequest(http.MethodPost, twilio.chatURL(resource), strings.NewReader(params.Encode()))
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(twilio.credentials())
+
+	res, err := twilio.post(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	decoder := json.NewDecoder(res.Body)
+
+	if res.StatusCode != http.StatusCreated {
+		err = new(Exception)
+
+		decoder.Decode(err)
+
+		return nil, err
+	}
+
+	response := new(ChatUser)
+
+	decoder.Decode(&response)
+
+	return response, nil
+}

--- a/pkg/chat_users_test.go
+++ b/pkg/chat_users_test.go
@@ -1,0 +1,139 @@
+package twiligo_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	twiligo "github.com/craigpaul/twiligo/pkg"
+)
+
+const createdChatUserResponse = `{
+	"sid": "USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"service_sid": "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"role_sid": "RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+	"identity": "Unique Name",
+	"attributes": "{}",
+	"is_online": null,
+	"is_notifiable": null,
+	"friendly_name": null,
+	"joined_channels_count": 0,
+	"date_created": "2020-07-30T00:00:00Z",
+	"date_updated": "2020-07-30T00:00:00Z",
+	"links": {
+		"user_channels": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Users/USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Channels",
+		"user_bindings": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Users/USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Bindings"
+	},
+	"url": "https://chat.twilio.com/v2/Services/ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Users/USXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}`
+
+const missingIdentityParameterResponse = `{
+	"code": 20001,
+	"message": "Missing required parameter Identity in the post body",
+	"more_info": "https://www.twilio.com/docs/errors/20001",
+	"status": 400
+}`
+
+func TestWillMakeRequestToCreateNewChatUserSuccessfully(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		expected := "Services/IS123/Users"
+
+		if strings.Contains(req.URL.Path, expected) == false {
+			t.Logf("Incorrect URL supplied, expecting URL to contain [%s], but received [%s]", expected, req.URL.Path)
+			t.Fail()
+		}
+
+		if req.Header.Get("Authorization") == "" {
+			t.Log("Missing authorization credentials, they should be supplied via the Authorization header")
+			t.Fail()
+		}
+
+		body, _ := ioutil.ReadAll(req.Body)
+		params, _ := url.ParseQuery(string(body))
+
+		if params.Get("Identity") != "Unique Name" {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", "Unique Name", params.Get("Identity"))
+			t.Fail()
+		}
+
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(createdChatUserResponse)),
+			StatusCode: http.StatusCreated,
+			Header:     make(http.Header),
+		}
+	})
+
+	response, err := twilio.CreateNewChatUser("Unique Name", "IS123", twiligo.CreateNewChatUserOptions{})
+
+	if err != nil {
+		t.Logf("Error was incorrectly returned, was not expecting the following error: %s", err)
+		t.Fail()
+	}
+
+	if response == nil {
+		t.Log("Did not receive the expected response")
+		t.Fail()
+	}
+}
+
+func TestWillIncludeProperRequestBodyParametersWhenMakingRequestToCreateNewChatUserSuccessfully(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		body, _ := ioutil.ReadAll(req.Body)
+		params, _ := url.ParseQuery(string(body))
+
+		if params.Get("RoleSid") != "RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", "RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", params.Get("RoleSid"))
+			t.Fail()
+		}
+
+		if params.Get("Attributes") != `{"custom":"value"}` {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", `{"custom":"value"}`, params.Get("Attributes"))
+			t.Fail()
+		}
+
+		if params.Get("FriendlyName") != "Friendly Name" {
+			t.Logf("Incorrect request parameter supplied, expecting [%s], but received [%s]", "Friendly Name", params.Get("FriendlyName"))
+			t.Fail()
+		}
+
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(createdChatUserResponse)),
+			StatusCode: http.StatusCreated,
+			Header:     make(http.Header),
+		}
+	})
+
+	twilio.CreateNewChatUser("Unique Name", "IS123", twiligo.CreateNewChatUserOptions{
+		RoleSID:      "RLXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		Attributes:   `{"custom":"value"}`,
+		FriendlyName: "Friendly Name",
+	})
+}
+
+func TestWillHandleErrorResponsesWhenMakingRequestToCreateNewChatUser(t *testing.T) {
+	twilio := NewTestTwilio(func(req *http.Request) *http.Response {
+		return &http.Response{
+			Body:       ioutil.NopCloser(bytes.NewBufferString(missingIdentityParameterResponse)),
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+		}
+	})
+
+	response, err := twilio.CreateNewChatUser("", "IS123", twiligo.CreateNewChatUserOptions{})
+
+	if response != nil {
+		t.Logf("Response was incorrectly returned, was not expecting the following response: %v", response)
+		t.Fail()
+	}
+
+	expected := "Missing required parameter Identity in the post body"
+
+	if err.Error() != expected {
+		t.Logf("Incorrect error returned, expected [%s], but received [%s]", expected, err)
+		t.Fail()
+	}
+}

--- a/pkg/helpers_test.go
+++ b/pkg/helpers_test.go
@@ -1,6 +1,7 @@
 package twiligo_test
 
 import (
+	"math/rand"
 	"net/http"
 
 	twiligo "github.com/craigpaul/twiligo/pkg"
@@ -23,4 +24,16 @@ func NewTestTwilio(fn RoundTripFunc) *twiligo.Twilio {
 
 func (fn RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req), nil
+}
+
+func RandomString(length int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	random := make([]rune, length)
+
+	for index := range random {
+		random[index] = letters[rand.Intn(len(letters))]
+	}
+
+	return string(random)
 }

--- a/pkg/jwt.go
+++ b/pkg/jwt.go
@@ -1,0 +1,163 @@
+package twiligo
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// AccessToken holds the necessary important information for encoding a JWT to use with various Twilio services.
+type AccessToken struct {
+	AccountSID    string
+	Grants        []Grant
+	Identity      *string
+	SigningKeySID string
+	Secret        string
+	TTL           int
+}
+
+// ChatGrant represents a specific type of Grant that is necessary to use Twilio's Programmable Chat.
+type ChatGrant struct {
+	EndpointID        *string
+	DeploymentRoleSID *string
+	PushCredentialSID *string
+	ServiceSID        *string
+}
+
+// Grant represents a type of permission that can be attached to an AccessToken.
+type Grant interface {
+	GetKey() string
+	GetPayload() map[string]string
+}
+
+// NewAccessTokenOptions represents the possible options that can be provided to a new AccessToken.
+type NewAccessTokenOptions struct {
+	Identity *string
+	TTL      *int
+}
+
+// NewChatGrantOptions represents the possible options that can be provided to a new ChatGrant.
+type NewChatGrantOptions struct {
+	EndpointID        *string
+	DeploymentRoleSID *string
+	PushCredentialSID *string
+	ServiceSID        *string
+}
+
+// NewAccessToken creates a new AccessToken with the given options.
+func NewAccessToken(accountSID, signingKeySID, secret string, options NewAccessTokenOptions) AccessToken {
+	ttl := options.TTL
+
+	if ttl == nil {
+		defaultTTL := 3600
+		ttl = &defaultTTL
+	}
+
+	return AccessToken{
+		AccountSID:    accountSID,
+		Identity:      options.Identity,
+		SigningKeySID: signingKeySID,
+		Secret:        secret,
+		TTL:           *ttl,
+	}
+}
+
+// NewChatGrant creates a new ChatGrant with the given options.
+func NewChatGrant(options NewChatGrantOptions) ChatGrant {
+	return ChatGrant{
+		EndpointID:        options.EndpointID,
+		DeploymentRoleSID: options.DeploymentRoleSID,
+		PushCredentialSID: options.PushCredentialSID,
+		ServiceSID:        options.ServiceSID,
+	}
+}
+
+// AddGrant appends a given grant to the current AccessToken.
+func (token *AccessToken) AddGrant(grant Grant) {
+	token.Grants = append(token.Grants, grant)
+}
+
+// ToJWT converts the given AccessToken attributes into a properly encoded and signed JWT.
+func (token *AccessToken) ToJWT() (string, error) {
+	now := time.Now()
+	method := jwt.SigningMethodHS256
+	signingKey := []byte(token.Secret)
+
+	grants := make(map[string]interface{})
+
+	for _, grant := range token.Grants {
+		payload := grant.GetPayload()
+
+		if payload == nil {
+			payload = make(map[string]string)
+		}
+
+		grants[grant.GetKey()] = payload
+	}
+
+	if token.Identity != nil {
+		grants["identity"] = token.Identity
+	}
+
+	jsonWebToken := jwt.NewWithClaims(method, jwt.MapClaims{
+		"jti":    token.SigningKeySID + "-" + strconv.FormatInt(now.Unix(), 10),
+		"iss":    token.SigningKeySID,
+		"sub":    token.AccountSID,
+		"iat":    now.Unix(),
+		"exp":    now.Add(time.Second * time.Duration(token.TTL)).Unix(),
+		"grants": grants,
+	})
+
+	jsonWebToken.Header = map[string]interface{}{
+		"alg": method.Name,
+		"cty": "twilio-fpa;v=1",
+		"typ": "JWT",
+	}
+
+	signedString, err := jsonWebToken.SignedString(signingKey)
+
+	if err != nil {
+		return "", err
+	}
+
+	return signedString, nil
+}
+
+func (token *AccessToken) String() string {
+	t, err := token.ToJWT()
+
+	if err != nil {
+		return ""
+	}
+
+	return t
+}
+
+// GetKey returns the string identifier for the current grant.
+func (grant ChatGrant) GetKey() string {
+	return "chat"
+}
+
+// GetPayload generates the full custom payload for the current grant.
+func (grant ChatGrant) GetPayload() map[string]string {
+	payload := make(map[string]string)
+
+	if grant.ServiceSID != nil {
+		payload["service_sid"] = *grant.ServiceSID
+	}
+
+	if grant.EndpointID != nil {
+		payload["endpoint_id"] = *grant.EndpointID
+	}
+
+	if grant.DeploymentRoleSID != nil {
+		payload["deployment_role_sid"] = *grant.DeploymentRoleSID
+	}
+
+	if grant.PushCredentialSID != nil {
+		payload["push_credential_sid"] = *grant.PushCredentialSID
+	}
+
+	return payload
+}

--- a/pkg/jwt_test.go
+++ b/pkg/jwt_test.go
@@ -1,0 +1,131 @@
+package twiligo_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	twiligo "github.com/craigpaul/twiligo/pkg"
+	"github.com/dgrijalva/jwt-go"
+)
+
+const accountSID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+const signingKeySID = "SKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+const ttl = 3600
+
+func TestCanGenerateAccessTokenWithEmptyGrants(t *testing.T) {
+	identity := "unique_identity"
+	secret := RandomString(32)
+
+	token := twiligo.NewAccessToken(accountSID, signingKeySID, secret, twiligo.NewAccessTokenOptions{
+		Identity: &identity,
+	})
+
+	jwtToken, err := token.ToJWT()
+
+	if err != nil {
+		t.Logf("Error was incorrectly returned, was not expecting the following error: %s", err)
+		t.Fail()
+	}
+
+	tok, err := jwt.Parse(jwtToken, getKeyFunc(secret))
+
+	if tok.Valid == false {
+		t.Log("Expecting a valid token to be parsed, but it was determined to be invalid")
+		t.Fail()
+	}
+
+	validateClaims(t, tok)
+}
+
+func TestCanGenerateAccessTokenWithChatGrant(t *testing.T) {
+	identity := "unique_identity"
+	secret := RandomString(32)
+
+	token := twiligo.NewAccessToken(accountSID, signingKeySID, secret, twiligo.NewAccessTokenOptions{
+		Identity: &identity,
+	})
+
+	serviceSID := "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+	grant := twiligo.NewChatGrant(twiligo.NewChatGrantOptions{
+		ServiceSID: &serviceSID,
+	})
+
+	token.AddGrant(grant)
+
+	jwtToken, err := token.ToJWT()
+
+	if err != nil {
+		t.Logf("Error was incorrectly returned, was not expecting the following error: %s", err)
+		t.Fail()
+	}
+
+	tok, err := jwt.Parse(jwtToken, getKeyFunc(secret))
+
+	if tok.Valid == false {
+		t.Log("Expecting a valid token to be parsed, but it was determined to be invalid")
+		t.Fail()
+	}
+
+	validateClaims(t, tok)
+
+	claims := tok.Claims.(jwt.MapClaims)
+	grants := claims["grants"].(map[string]interface{})
+
+	if grants["chat"] == nil {
+		t.Log("Expecting a chat grant to exist, but it was not found")
+		t.Fail()
+	}
+}
+
+func getKeyFunc(secret string) jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		_, ok := token.Method.(*jwt.SigningMethodHMAC)
+
+		if !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+
+		return []byte(secret), nil
+	}
+}
+
+func validateClaims(t *testing.T, token *jwt.Token) {
+	claims := token.Claims.(jwt.MapClaims)
+
+	sub := claims["sub"]
+	exp := int64(claims["exp"].(float64))
+	iat := int64(claims["iat"].(float64))
+	iss := claims["iss"]
+	jti := claims["jti"]
+	grants := claims["grants"].(map[string]interface{})
+	identity := grants["identity"]
+
+	if sub != accountSID {
+		t.Logf("Incorrect sub claim returned, expecting [%s], but received [%s]", accountSID, sub)
+		t.Fail()
+	}
+
+	if iat+ttl != exp {
+		t.Logf("Incorrect expiry claim returned, expecting [%d], but received [%d]", exp, iat+ttl)
+		t.Fail()
+	}
+
+	if iss != signingKeySID {
+		t.Logf("Incorrect issuer claim returned, expecting [%s], but received [%s]", signingKeySID, iss)
+		t.Fail()
+	}
+
+	expected := signingKeySID + "-" + strconv.FormatInt(iat, 10)
+
+	if jti.(string) != expected {
+		t.Logf("Incorrect JWT ID supplied, expecting [%s], but received [%s]", expected, jti.(string))
+		t.Fail()
+	}
+
+	if identity != "unique_identity" {
+		t.Logf("Incorrect identity supplied, expecting [%s], but received [%s]", "unique_identity", identity)
+		t.Fail()
+	}
+}

--- a/pkg/proxy_phone_numbers.go
+++ b/pkg/proxy_phone_numbers.go
@@ -43,14 +43,14 @@ type ProxyPhoneNumberCapabilities struct {
 }
 
 // AddPhoneNumberToProxyService attaches a phone number to the given proxy service in Twilio.
-func (twilio *Twilio) AddPhoneNumberToProxyService(service string, options AddPhoneNumberToProxyServiceOptions) (*ProxyPhoneNumber, error) {
+func (twilio *Twilio) AddPhoneNumberToProxyService(serviceSID string, options AddPhoneNumberToProxyServiceOptions) (*ProxyPhoneNumber, error) {
 	params, err := query.Values(options)
 
 	if err != nil {
 		return nil, err
 	}
 
-	resource := "Services/" + service + "/PhoneNumbers"
+	resource := "Services/" + serviceSID + "/PhoneNumbers"
 
 	req, err := http.NewRequest(http.MethodPost, twilio.proxyURL(resource), strings.NewReader(params.Encode()))
 

--- a/pkg/twiligo.go
+++ b/pkg/twiligo.go
@@ -7,6 +7,7 @@ import (
 )
 
 const baseURL string = "https://api.twilio.com/2010-04-01"
+const chatBaseURL string = "https://chat.twilio.com/v2"
 const proxyBaseURL string = "https://proxy.twilio.com/v1"
 
 // Exception represents an exception / bad response from the Twilio REST API.
@@ -61,6 +62,10 @@ func (twilio *Twilio) post(req *http.Request) (*http.Response, error) {
 
 func (twilio *Twilio) delete(req *http.Request) (*http.Response, error) {
 	return twilio.HTTPClient.Do(req)
+}
+
+func (twilio *Twilio) chatURL(resource string) string {
+	return chatBaseURL + "/" + resource
 }
 
 func (twilio *Twilio) proxyURL(resource string) string {


### PR DESCRIPTION
This PR is meant to allow consumers to create new chat services through Twilio. Future PRs will improve upon this by allowing us to create new users belonging to these chat services, generating access tokens, etc.