### PR TITLE
Feature/create chat access tokens

### DIFF
--- a/pkg/available_phone_numbers.go
+++ b/pkg/available_phone_numbers.go
@@ -112,7 +112,7 @@ func (twilio *Twilio) GetAvailablePhoneNumbers(country string, number PhoneNumbe
 }
 
 // GetPhoneNumberType will convert a given integer into a PhoneNumberType by the given country. Certain countries do not support all PhoneNumberType values, so this function can be used as a safe mapping based on the values from this document https://support.twilio.com/hc/en-us/articles/223183068-Twilio-international-phone-number-availability-and-their-capabilities. Note: Not all cases are currently supported, but can be amended as necessary.
-func (twilio *Twilio) GetPhoneNumberType(number int, country string) PhoneNumberType {
+func GetPhoneNumberType(number int, country string) PhoneNumberType {
 	numberType := PhoneNumberType(number)
 
 	if (country == "CA" || country == "US") && numberType == Mobile {

--- a/pkg/available_phone_numbers_test.go
+++ b/pkg/available_phone_numbers_test.go
@@ -214,11 +214,9 @@ func TestWillConvertGivenNumberTypeAndCountryToMatchingPhoneNumberTypeToPrevent4
 		"FR": {twiligo.Mobile: twiligo.Mobile, twiligo.Local: twiligo.Local},
 	}
 
-	twilio := twiligo.New("123", "456")
-
 	for country, values := range cases {
 		for given, expected := range values {
-			numberType := twilio.GetPhoneNumberType(int(given), country)
+			numberType := twiligo.GetPhoneNumberType(int(given), country)
 
 			if numberType != expected {
 				t.Logf("Incorrect number type returned, expected [%s], but received [%s]", expected, numberType)

--- a/pkg/helpers_test.go
+++ b/pkg/helpers_test.go
@@ -1,6 +1,7 @@
 package twiligo_test
 
 import (
+	"math/rand"
 	"net/http"
 
 	twiligo "github.com/craigpaul/twiligo/pkg"
@@ -23,4 +24,16 @@ func NewTestTwilio(fn RoundTripFunc) *twiligo.Twilio {
 
 func (fn RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return fn(req), nil
+}
+
+func RandomString(length int) string {
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	random := make([]rune, length)
+
+	for index := range random {
+		random[index] = letters[rand.Intn(len(letters))]
+	}
+
+	return string(random)
 }

--- a/pkg/jwt.go
+++ b/pkg/jwt.go
@@ -19,7 +19,10 @@ type AccessToken struct {
 
 // ChatGrant represents a specific type of Grant that is necessary to use Twilio's Programmable Chat.
 type ChatGrant struct {
-	ServiceSID *string
+	EndpointID        *string
+	DeploymentRoleSID *string
+	PushCredentialSID *string
+	ServiceSID        *string
 }
 
 // Grant represents a type of permission that can be attached to an AccessToken.
@@ -30,33 +33,43 @@ type Grant interface {
 
 // NewAccessTokenOptions represents the possible options that can be provided to a new AccessToken.
 type NewAccessTokenOptions struct {
-	AccountSID    string
-	Identity      *string
-	SigningKeySID string
-	Secret        string
-	TTL           int
+	Identity *string
+	TTL      *int
 }
 
 // NewChatGrantOptions represents the possible options that can be provided to a new ChatGrant.
 type NewChatGrantOptions struct {
-	ServiceSID *string
+	EndpointID        *string
+	DeploymentRoleSID *string
+	PushCredentialSID *string
+	ServiceSID        *string
 }
 
 // NewAccessToken creates a new AccessToken with the given options.
-func NewAccessToken(options NewAccessTokenOptions) AccessToken {
+func NewAccessToken(accountSID, signingKeySID, secret string, options NewAccessTokenOptions) AccessToken {
+	ttl := options.TTL
+
+	if ttl == nil {
+		defaultTTL := 3600
+		ttl = &defaultTTL
+	}
+
 	return AccessToken{
-		AccountSID:    options.AccountSID,
+		AccountSID:    accountSID,
 		Identity:      options.Identity,
-		SigningKeySID: options.SigningKeySID,
-		Secret:        options.Secret,
-		TTL:           options.TTL,
+		SigningKeySID: signingKeySID,
+		Secret:        secret,
+		TTL:           *ttl,
 	}
 }
 
 // NewChatGrant creates a new ChatGrant with the given options.
 func NewChatGrant(options NewChatGrantOptions) ChatGrant {
 	return ChatGrant{
-		ServiceSID: options.ServiceSID,
+		EndpointID:        options.EndpointID,
+		DeploymentRoleSID: options.DeploymentRoleSID,
+		PushCredentialSID: options.PushCredentialSID,
+		ServiceSID:        options.ServiceSID,
 	}
 }
 
@@ -132,6 +145,18 @@ func (grant ChatGrant) GetPayload() map[string]string {
 
 	if grant.ServiceSID != nil {
 		payload["service_sid"] = *grant.ServiceSID
+	}
+
+	if grant.EndpointID != nil {
+		payload["endpoint_id"] = *grant.EndpointID
+	}
+
+	if grant.DeploymentRoleSID != nil {
+		payload["deployment_role_sid"] = *grant.DeploymentRoleSID
+	}
+
+	if grant.PushCredentialSID != nil {
+		payload["push_credential_sid"] = *grant.PushCredentialSID
 	}
 
 	return payload

--- a/pkg/jwt.go
+++ b/pkg/jwt.go
@@ -1,0 +1,138 @@
+package twiligo
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// AccessToken ...
+type AccessToken struct {
+	AccountSID    string
+	Grants        []Grant
+	Identity      *string
+	SigningKeySID string
+	Secret        string
+	TTL           int
+}
+
+// ChatGrant ...
+type ChatGrant struct {
+	ServiceSID *string
+}
+
+// Grant ...
+type Grant interface {
+	GetKey() string
+	GetPayload() map[string]string
+}
+
+// NewAccessTokenOptions ...
+type NewAccessTokenOptions struct {
+	AccountSID    string
+	Identity      *string
+	SigningKeySID string
+	Secret        string
+	TTL           int
+}
+
+// NewChatGrantOptions ...
+type NewChatGrantOptions struct {
+	ServiceSID *string
+}
+
+// NewAccessToken ...
+func NewAccessToken(options NewAccessTokenOptions) AccessToken {
+	return AccessToken{
+		AccountSID:    options.AccountSID,
+		Identity:      options.Identity,
+		SigningKeySID: options.SigningKeySID,
+		Secret:        options.Secret,
+		TTL:           options.TTL,
+	}
+}
+
+// NewChatGrant ...
+func NewChatGrant(options NewChatGrantOptions) ChatGrant {
+	return ChatGrant{
+		ServiceSID: options.ServiceSID,
+	}
+}
+
+// AddGrant ...
+func (token *AccessToken) AddGrant(grant Grant) {
+	token.Grants = append(token.Grants, grant)
+}
+
+// ToJWT ...
+func (token *AccessToken) ToJWT() (string, error) {
+	now := time.Now()
+	method := jwt.SigningMethodHS256
+	signingKey := []byte(token.Secret)
+
+	grants := make(map[string]interface{})
+
+	for _, grant := range token.Grants {
+		payload := grant.GetPayload()
+
+		if payload == nil {
+			payload = make(map[string]string)
+		}
+
+		grants[grant.GetKey()] = payload
+	}
+
+	if token.Identity != nil {
+		grants["identity"] = token.Identity
+	}
+
+	jsonWebToken := jwt.NewWithClaims(method, jwt.MapClaims{
+		"jti":    token.SigningKeySID + "-" + strconv.FormatInt(now.Unix(), 10),
+		"iss":    token.SigningKeySID,
+		"sub":    token.AccountSID,
+		"iat":    now.Unix(),
+		"exp":    now.Add(time.Second * time.Duration(token.TTL)).Unix(),
+		"grants": grants,
+	})
+
+	jsonWebToken.Header = map[string]interface{}{
+		"alg": method.Name,
+		"cty": "twilio-fpa;v=1",
+		"typ": "JWT",
+	}
+
+	signedString, err := jsonWebToken.SignedString(signingKey)
+
+	if err != nil {
+		return "", err
+	}
+
+	return signedString, nil
+}
+
+func (token *AccessToken) String() string {
+	t, err := token.ToJWT()
+
+	if err != nil {
+		return ""
+	}
+
+	return t
+}
+
+// GetKey ...
+func (grant ChatGrant) GetKey() string {
+	return "chat"
+}
+
+// GetPayload ...
+func (grant ChatGrant) GetPayload() map[string]string {
+	payload := make(map[string]string)
+
+	if grant.ServiceSID != nil {
+		payload["service_sid"] = *grant.ServiceSID
+	}
+
+	return payload
+}

--- a/pkg/jwt.go
+++ b/pkg/jwt.go
@@ -7,7 +7,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 )
 
-// AccessToken ...
+// AccessToken holds the necessary important information for encoding a JWT to use with various Twilio services.
 type AccessToken struct {
 	AccountSID    string
 	Grants        []Grant
@@ -17,18 +17,18 @@ type AccessToken struct {
 	TTL           int
 }
 
-// ChatGrant ...
+// ChatGrant represents a specific type of Grant that is necessary to use Twilio's Programmable Chat.
 type ChatGrant struct {
 	ServiceSID *string
 }
 
-// Grant ...
+// Grant represents a type of permission that can be attached to an AccessToken.
 type Grant interface {
 	GetKey() string
 	GetPayload() map[string]string
 }
 
-// NewAccessTokenOptions ...
+// NewAccessTokenOptions represents the possible options that can be provided to a new AccessToken.
 type NewAccessTokenOptions struct {
 	AccountSID    string
 	Identity      *string
@@ -37,12 +37,12 @@ type NewAccessTokenOptions struct {
 	TTL           int
 }
 
-// NewChatGrantOptions ...
+// NewChatGrantOptions represents the possible options that can be provided to a new ChatGrant.
 type NewChatGrantOptions struct {
 	ServiceSID *string
 }
 
-// NewAccessToken ...
+// NewAccessToken creates a new AccessToken with the given options.
 func NewAccessToken(options NewAccessTokenOptions) AccessToken {
 	return AccessToken{
 		AccountSID:    options.AccountSID,
@@ -53,19 +53,19 @@ func NewAccessToken(options NewAccessTokenOptions) AccessToken {
 	}
 }
 
-// NewChatGrant ...
+// NewChatGrant creates a new ChatGrant with the given options.
 func NewChatGrant(options NewChatGrantOptions) ChatGrant {
 	return ChatGrant{
 		ServiceSID: options.ServiceSID,
 	}
 }
 
-// AddGrant ...
+// AddGrant appends a given grant to the current AccessToken.
 func (token *AccessToken) AddGrant(grant Grant) {
 	token.Grants = append(token.Grants, grant)
 }
 
-// ToJWT ...
+// ToJWT converts the given AccessToken attributes into a properly encoded and signed JWT.
 func (token *AccessToken) ToJWT() (string, error) {
 	now := time.Now()
 	method := jwt.SigningMethodHS256
@@ -121,12 +121,12 @@ func (token *AccessToken) String() string {
 	return t
 }
 
-// GetKey ...
+// GetKey returns the string identifier for the current grant.
 func (grant ChatGrant) GetKey() string {
 	return "chat"
 }
 
-// GetPayload ...
+// GetPayload generates the full custom payload for the current grant.
 func (grant ChatGrant) GetPayload() map[string]string {
 	payload := make(map[string]string)
 

--- a/pkg/jwt_test.go
+++ b/pkg/jwt_test.go
@@ -17,12 +17,8 @@ func TestCanGenerateAccessTokenWithEmptyGrants(t *testing.T) {
 	identity := "unique_identity"
 	secret := RandomString(32)
 
-	token := twiligo.NewAccessToken(twiligo.NewAccessTokenOptions{
-		AccountSID:    accountSID,
-		Identity:      &identity,
-		SigningKeySID: signingKeySID,
-		Secret:        secret,
-		TTL:           ttl,
+	token := twiligo.NewAccessToken(accountSID, signingKeySID, secret, twiligo.NewAccessTokenOptions{
+		Identity: &identity,
 	})
 
 	jwtToken, err := token.ToJWT()
@@ -46,12 +42,8 @@ func TestCanGenerateAccessTokenWithChatGrant(t *testing.T) {
 	identity := "unique_identity"
 	secret := RandomString(32)
 
-	token := twiligo.NewAccessToken(twiligo.NewAccessTokenOptions{
-		AccountSID:    accountSID,
-		Identity:      &identity,
-		SigningKeySID: signingKeySID,
-		Secret:        secret,
-		TTL:           ttl,
+	token := twiligo.NewAccessToken(accountSID, signingKeySID, secret, twiligo.NewAccessTokenOptions{
+		Identity: &identity,
 	})
 
 	serviceSID := "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"

--- a/pkg/jwt_test.go
+++ b/pkg/jwt_test.go
@@ -1,0 +1,139 @@
+package twiligo_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	twiligo "github.com/craigpaul/twiligo/pkg"
+	"github.com/dgrijalva/jwt-go"
+)
+
+const accountSID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+const signingKeySID = "SKXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+const ttl = 3600
+
+func TestCanGenerateAccessTokenWithEmptyGrants(t *testing.T) {
+	identity := "unique_identity"
+	secret := RandomString(32)
+
+	token := twiligo.NewAccessToken(twiligo.NewAccessTokenOptions{
+		AccountSID:    accountSID,
+		Identity:      &identity,
+		SigningKeySID: signingKeySID,
+		Secret:        secret,
+		TTL:           ttl,
+	})
+
+	jwtToken, err := token.ToJWT()
+
+	if err != nil {
+		t.Logf("Error was incorrectly returned, was not expecting the following error: %s", err)
+		t.Fail()
+	}
+
+	tok, err := jwt.Parse(jwtToken, getKeyFunc(secret))
+
+	if tok.Valid == false {
+		t.Log("Expecting a valid token to be parsed, but it was determined to be invalid")
+		t.Fail()
+	}
+
+	validateClaims(t, tok)
+}
+
+func TestCanGenerateAccessTokenWithChatGrant(t *testing.T) {
+	identity := "unique_identity"
+	secret := RandomString(32)
+
+	token := twiligo.NewAccessToken(twiligo.NewAccessTokenOptions{
+		AccountSID:    accountSID,
+		Identity:      &identity,
+		SigningKeySID: signingKeySID,
+		Secret:        secret,
+		TTL:           ttl,
+	})
+
+	serviceSID := "ISXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+	grant := twiligo.NewChatGrant(twiligo.NewChatGrantOptions{
+		ServiceSID: &serviceSID,
+	})
+
+	token.AddGrant(grant)
+
+	jwtToken, err := token.ToJWT()
+
+	if err != nil {
+		t.Logf("Error was incorrectly returned, was not expecting the following error: %s", err)
+		t.Fail()
+	}
+
+	tok, err := jwt.Parse(jwtToken, getKeyFunc(secret))
+
+	if tok.Valid == false {
+		t.Log("Expecting a valid token to be parsed, but it was determined to be invalid")
+		t.Fail()
+	}
+
+	validateClaims(t, tok)
+
+	claims := tok.Claims.(jwt.MapClaims)
+	grants := claims["grants"].(map[string]interface{})
+
+	if grants["chat"] == nil {
+		t.Log("Expecting a chat grant to exist, but it was not found")
+		t.Fail()
+	}
+}
+
+func getKeyFunc(secret string) jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		_, ok := token.Method.(*jwt.SigningMethodHMAC)
+
+		if !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+
+		return []byte(secret), nil
+	}
+}
+
+func validateClaims(t *testing.T, token *jwt.Token) {
+	claims := token.Claims.(jwt.MapClaims)
+
+	sub := claims["sub"]
+	exp := int64(claims["exp"].(float64))
+	iat := int64(claims["iat"].(float64))
+	iss := claims["iss"]
+	jti := claims["jti"]
+	grants := claims["grants"].(map[string]interface{})
+	identity := grants["identity"]
+
+	if sub != accountSID {
+		t.Logf("Incorrect sub claim returned, expecting [%s], but received [%s]", accountSID, sub)
+		t.Fail()
+	}
+
+	if iat+ttl != exp {
+		t.Logf("Incorrect expiry claim returned, expecting [%d], but received [%d]", exp, iat+ttl)
+		t.Fail()
+	}
+
+	if iss != signingKeySID {
+		t.Logf("Incorrect issuer claim returned, expecting [%s], but received [%s]", signingKeySID, iss)
+		t.Fail()
+	}
+
+	expected := signingKeySID + "-" + strconv.FormatInt(iat, 10)
+
+	if jti.(string) != expected {
+		t.Logf("Incorrect JWT ID supplied, expecting [%s], but received [%s]", expected, jti.(string))
+		t.Fail()
+	}
+
+	if identity != "unique_identity" {
+		t.Logf("Incorrect identity supplied, expecting [%s], but received [%s]", "unique_identity", identity)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This PR aims to implement the [ability the encode a JWT for use with the Twilio Programmable Chat](https://www.twilio.com/docs/chat/create-tokens) service. Twilio offers libraries to help with this in various languages. Unfortunately, one of those languages is not Golang.

If there are any thoughts on how to improve the tests or how the access token + grant flow works, I'm open to suggestions.